### PR TITLE
Task/rework top app bar

### DIFF
--- a/example/src/AppBar/AppBarPage.tsx
+++ b/example/src/AppBar/AppBarPage.tsx
@@ -1,7 +1,7 @@
 import type { NavigationProp } from '@react-navigation/native';
-import React, { useEffect, useState } from 'react';
-import { AppBar, BottomSheet, Button, Menu, Screen, useTheme } from 'smartway-react-native-ui';
-import type { DropDownOption } from 'src/components/dropDown/DropDown';
+import React, { useState } from 'react';
+import { View } from 'react-native';
+import { AppBar, BottomSheet, Button, Screen, useTheme } from 'smartway-react-native-ui';
 
 interface Props {
     navigation: NavigationProp<any>;
@@ -9,53 +9,53 @@ interface Props {
 
 export const AppBarPage = ({ navigation }: Props) => {
     const theme = useTheme();
-    const [selected, setSelected] = useState<DropDownOption>();
     const [isOpened, setOpened] = useState<boolean>(false);
-    const menuOptions = [
-        { title: 'option 1', onPress: () => console.log('option') },
-        { title: 'option 2', onPress: () => console.log('option') },
-        { title: 'option 3', onPress: () => console.log('option') },
-        { title: 'option 4', onPress: () => console.log('option') },
-    ];
-
-    const options: DropDownOption[] = [
-        { value: 'Revalorisation auto' },
-        { value: 'Option 2' },
-        { value: 'Option 3' },
-        { value: 'Option 4' },
-    ];
 
     const goBack = () => {
         navigation.goBack();
     };
 
-    useEffect(() => {
-        setSelected(options[0]);
-    }, []);
+    const menu = (
+        <View>
+            <Button mode="outlined" onClick={() => setOpened(true)}>
+                {'Revalorisation'}
+            </Button>
+        </View>
+    );
 
     return (
         <Screen style={{ backgroundColor: theme.sw.colors.neutral[50], paddingTop: 16 }}>
             <AppBar
-                style={{ paddingBottom: theme.sw.spacing.m }}
-                iconName="arrow-back"
-                label={'Title'}
-                onIconPress={goBack}
-            >
-                <Menu icon="more" options={menuOptions} />
-            </AppBar>
+                onTitlePress={() => setOpened(true)}
+                onBack={goBack}
+                title="Title"
+                subtitle="Label"
+                firstIconName="dots-vertical"
+                secondIconName="dots-vertical"
+            />
             <AppBar
-                onPress={() => setOpened(true)}
-                label={selected?.value}
-                disabled={isOpened}
-                iconName="arrow-back"
-                type="accordion"
-            >
-                <Menu
-                    icon="settings"
-                    style={{ position: 'absolute', right: 16, top: 12 }}
-                    options={menuOptions}
-                />
-            </AppBar>
+                size="medium"
+                onTitlePress={() => setOpened(true)}
+                onBack={goBack}
+                title="Title"
+                subtitle="Long Label"
+                firstIconName="dots-vertical"
+                secondIconName="dots-vertical"
+            />
+            <AppBar
+                size="center-aligned"
+                onTitlePress={() => setOpened(true)}
+                onBack={goBack}
+                title="Title"
+                firstIconName="dots-vertical"
+            />
+            <AppBar
+                size="center-aligned"
+                onTitlePress={() => setOpened(true)}
+                onBack={goBack}
+                title={menu}
+                firstIconName="cog"
+            />
             <BottomSheet
                 snapPoints={['40%']}
                 swipeable={true}
@@ -64,7 +64,9 @@ export const AppBarPage = ({ navigation }: Props) => {
                 isOpened={isOpened}
                 onClose={() => setOpened(false)}
             >
-                <Button mode="filled">Option</Button>
+                <Button mode="filled" onClick={() => setOpened(false)}>
+                    Option
+                </Button>
             </BottomSheet>
         </Screen>
     );

--- a/src/components/appBar/AppBar.tsx
+++ b/src/components/appBar/AppBar.tsx
@@ -1,102 +1,69 @@
-import React from 'react';
-import { Pressable, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
-
+import React, { ReactNode } from 'react';
+import { Appbar } from 'react-native-paper';
 import { useTheme } from '../../styles/themes';
-import { Icon } from '../icons/Icon';
-import type { IconName } from '../icons/IconProps';
-import { Body } from '../typography/Body';
+import type { ViewStyle } from 'react-native';
 import { Headline } from '../typography/Headline';
+import { Button } from '../buttons/Button';
+import type { IconSource } from 'react-native-paper/lib/typescript/src/components/Icon';
 
-type AppBarType = 'default' | 'accordion';
 interface Props {
-    label?: string;
-    onPress?: () => void;
-    onIconPress?: () => void;
-    iconName?: IconName;
+    size?: 'small' | 'medium' | 'large' | 'center-aligned';
+    title: ReactNode;
+    onTitlePress?: () => void;
+    subtitle?: string;
+    onSubtitlePress?: () => void;
+    firstIconName?: IconSource;
+    onFirstIconPress?: () => void;
+    secondIconName?: IconSource;
+    onSecondIconPress?: () => void;
+    onBack?: () => void;
     style?: ViewStyle;
-    children?: JSX.Element;
-    type?: AppBarType;
-    disabled?: boolean;
 }
+
 export const AppBar = ({
-    label,
-    onPress,
-    onIconPress,
-    iconName = 'arrow-back',
+    size = 'small',
+    title,
+    onTitlePress,
+    subtitle,
+    onSubtitlePress,
+    firstIconName,
+    secondIconName,
+    onFirstIconPress,
+    onSecondIconPress,
+    onBack,
     style,
-    children,
-    type = 'default',
-    disabled,
 }: Props) => {
     const theme = useTheme();
 
-    const styles = StyleSheet.create({
-        header: {
-            justifyContent: 'space-between',
-            flexDirection: 'row',
-            backgroundColor: theme.sw.colors.neutral[50],
-            ...style,
-        },
-
-        appBar: {
-            backgroundColor: theme.sw.colors.neutral[50],
-        },
-        appBarAction: {
-            justifyContent: 'center',
-            marginRight: theme.sw.spacing.s,
-        },
-        container: {
-            flexDirection: 'row',
-            justifyContent: 'center',
-            ...style,
-        },
-        touchableOpacity: {
-            paddingHorizontal: theme.sw.spacing.l,
-            paddingVertical: theme.sw.spacing.m,
-            borderRadius: 8,
-            flexDirection: 'row',
-            justifyContent: 'center',
-            alignItems: 'center',
-            backgroundColor: theme.sw.colors.neutral[300],
-            ...style,
-        },
-        body: {
-            paddingRight: theme.sw.spacing.m,
-            color: disabled ? theme.sw.colors.neutral[500] : theme.sw.colors.neutral[800],
-            lineHeight: 26,
-        },
-    });
-
-    if (type === 'default') {
-        return (
-            <View style={styles.header}>
-                <View style={styles.container}>
-                    {onIconPress && (
-                        <Pressable onPress={onIconPress} style={styles.appBarAction}>
-                            <Icon size={20} name={iconName} />
-                        </Pressable>
-                    )}
-                    <Headline size="h3">{label}</Headline>
-                </View>
-                {children}
-            </View>
-        );
-    } else {
-        return (
-            <View style={styles.container}>
-                <TouchableOpacity onPress={onPress} style={styles.touchableOpacity}>
-                    <Body size="semi-bold" style={styles.body}>
-                        {label}
-                    </Body>
-                    <Icon
-                        color={
-                            disabled ? theme.sw.colors.neutral[500] : theme.sw.colors.neutral[800]
-                        }
-                        name="arrow-down"
-                    />
-                </TouchableOpacity>
-                {children}
-            </View>
-        );
-    }
+    const getIconColor = () => {
+        return theme.sw.colors.neutral[600];
+    };
+    return (
+        <Appbar.Header mode={size} style={style}>
+            {onBack !== undefined && <Appbar.BackAction onPress={onBack} />}
+            <Appbar.Content
+                title={typeof title === 'string' ? <Headline size="h2">{title}</Headline> : title}
+                onPress={onTitlePress}
+            />
+            {subtitle !== undefined && (
+                <Button mode="text" onClick={onSubtitlePress}>
+                    {subtitle}
+                </Button>
+            )}
+            {secondIconName !== undefined && (
+                <Appbar.Action
+                    icon={secondIconName}
+                    onPress={onSecondIconPress}
+                    color={getIconColor()}
+                />
+            )}
+            {firstIconName !== undefined && (
+                <Appbar.Action
+                    icon={firstIconName}
+                    onPress={onFirstIconPress}
+                    color={getIconColor()}
+                />
+            )}
+        </Appbar.Header>
+    );
 };

--- a/src/components/dropDown/DropDown.tsx
+++ b/src/components/dropDown/DropDown.tsx
@@ -60,6 +60,12 @@ export const DropDown = ({
                 borderColor: theme.sw.colors.error[400],
             };
         }
+        if (selected) {
+            return {
+                color: theme.sw.colors.neutral[800],
+                borderColor: theme.sw.colors.neutral[400],
+            };
+        }
         return {
             color: theme.sw.colors.neutral[500],
             borderColor: theme.sw.colors.neutral[400],


### PR DESCRIPTION
Gros rework pour utiliser le composant Paper car il fait exactement ce que nous voulons, et Hélène s'est basé dessus. Ca simplifie donc pas mal de choses.
Pour moi, les menus type "Revalorisation" devraient venir de l'appelant, ici on se contente d'avoir des boutons cliquables.

Ca donne ça :
![image](https://user-images.githubusercontent.com/84324109/236143733-ce3babb9-c2da-47a0-b8ba-fd7789692928.png)

Pour info le design kit : https://www.figma.com/file/MD0xdHA7E93GKAwkSRpduK/%F0%9F%93%B1-SW-Mobile---Design-Kit?type=design&node-id=1224-1657&t=pLSup6IFxC5lUhLF-0

Les diff de style du titre notamment viennent des composant headline et body qui ne sont plus à jour.

Le seul truc qui m'embête c'est le subtitle ("label" sur la maquette), pour lequel j'ai utilisé notre bouton pour le moment, mais du fait des styles qui lui sont appliqués, on a un truc tronqué, il faudra donc revoir ça et potentiellement utiliser autre chose que notre bouton.