### PR TITLE
Task/rework action card

### DIFF
--- a/src/__tests__/components/ActionCard.test.tsx
+++ b/src/__tests__/components/ActionCard.test.tsx
@@ -17,7 +17,9 @@ describe('MODULE | ActionCard', () => {
                             <Text>Test</Text>
                         </View>
                     }
-                />
+                >
+                    {'Test children'}
+                </ActionCard>
             </ThemeProvider>,
         ).toJSON();
         expect(tree).toMatchSnapshot();
@@ -33,7 +35,9 @@ describe('MODULE | ActionCard', () => {
                             <Text>Test</Text>
                         </View>
                     }
-                />
+                >
+                    {'Test children'}
+                </ActionCard>
             </ThemeProvider>,
         ).toJSON();
         expect(tree).toMatchSnapshot();
@@ -50,7 +54,9 @@ describe('MODULE | ActionCard', () => {
                         </View>
                     }
                     buttonTestID={mockedTestID}
-                />
+                >
+                    {'Test children'}
+                </ActionCard>
             </ThemeProvider>,
         );
 

--- a/src/__tests__/components/ActionCard.test.tsx
+++ b/src/__tests__/components/ActionCard.test.tsx
@@ -46,7 +46,8 @@ describe('MODULE | ActionCard', () => {
         const tree = render(
             <ThemeProvider>
                 <ActionCard
-                    onClose={mockedCallback}
+                    onClear={mockedCallback}
+                    displayClear={true}
                     titleColor={'black'}
                     bottomChildren={
                         <View>

--- a/src/__tests__/components/__snapshots__/ActionCard.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/ActionCard.test.tsx.snap
@@ -63,22 +63,17 @@ exports[`MODULE | ActionCard component renders correctly 1`] = `
             style={
               {
                 "color": "black",
-                "fontFamily": "PublicSans-SemiBold",
+                "fontFamily": "PublicSans-Regular",
                 "fontSize": 16,
-                "fontWeight": "600",
                 "lineHeight": 19,
-                "paddingTop": 16,
+                "paddingBottom": 16,
                 "textAlign": "center",
               }
             }
           />
-          <View
-            style={
-              {
-                "padding": 16,
-              }
-            }
-          />
+          <View>
+            Test children
+          </View>
           <View
             style={
               {
@@ -91,7 +86,8 @@ exports[`MODULE | ActionCard component renders correctly 1`] = `
                 {
                   "backgroundColor": "#F4F6F8",
                   "height": 1,
-                  "marginVertical": 32,
+                  "marginBottom": 6,
+                  "marginTop": 16,
                   "width": "100%",
                 }
               }
@@ -100,7 +96,6 @@ exports[`MODULE | ActionCard component renders correctly 1`] = `
               style={
                 {
                   "alignItems": "center",
-                  "paddingBottom": 32,
                 }
               }
             >
@@ -181,22 +176,17 @@ exports[`MODULE | ActionCard component renders correctly in disabled state 1`] =
             style={
               {
                 "color": "black",
-                "fontFamily": "PublicSans-SemiBold",
+                "fontFamily": "PublicSans-Regular",
                 "fontSize": 16,
-                "fontWeight": "600",
                 "lineHeight": 19,
-                "paddingTop": 16,
+                "paddingBottom": 16,
                 "textAlign": "center",
               }
             }
           />
-          <View
-            style={
-              {
-                "padding": 16,
-              }
-            }
-          />
+          <View>
+            Test children
+          </View>
           <View
             style={
               {
@@ -209,7 +199,8 @@ exports[`MODULE | ActionCard component renders correctly in disabled state 1`] =
                 {
                   "backgroundColor": "#F4F6F8",
                   "height": 1,
-                  "marginVertical": 32,
+                  "marginBottom": 6,
+                  "marginTop": 16,
                   "width": "100%",
                 }
               }
@@ -218,7 +209,6 @@ exports[`MODULE | ActionCard component renders correctly in disabled state 1`] =
               style={
                 {
                   "alignItems": "center",
-                  "paddingBottom": 32,
                 }
               }
             >

--- a/src/components/actionCard/ActionCard.tsx
+++ b/src/components/actionCard/ActionCard.tsx
@@ -7,13 +7,14 @@ import { Body } from '../typography/Body';
 import DropShadow from 'react-native-drop-shadow';
 
 interface Props {
-    children?: ReactNode;
+    children: ReactNode;
     bottomChildren: ReactNode;
     title?: string;
     titleColor: string;
     style?: ViewStyle;
     disabled?: boolean;
-    onClose?: () => void;
+    onClear?: () => void;
+    displayClear?: boolean;
     buttonTestID?: string;
 }
 
@@ -24,7 +25,8 @@ export const ActionCard = ({
     titleColor,
     bottomChildren,
     disabled,
-    onClose,
+    onClear,
+    displayClear = false,
     buttonTestID,
 }: Props) => {
     const theme = useTheme();
@@ -87,16 +89,17 @@ export const ActionCard = ({
             <DropShadow style={styles.smallShadow}>
                 <View style={styles.container}>
                     <Body style={styles.title}>{title}</Body>
-                    <Pressable style={styles.close} onPress={onClose} testID={buttonTestID}>
-                        <Icon name="close-fill" size={20} />
-                    </Pressable>
-                    <View>{children}</View>
-                    {bottomChildren && (
-                        <View style={{ width: '100%' }}>
-                            <View style={styles.divider} />
-                            <View style={styles.bottomChildren}>{bottomChildren}</View>
-                        </View>
+                    {displayClear && (
+                        <Pressable style={styles.close} onPress={onClear} testID={buttonTestID}>
+                            <Icon name="close-fill" size={20} />
+                        </Pressable>
                     )}
+                    <View>{children}</View>
+
+                    <View style={{ width: '100%' }}>
+                        <View style={styles.divider} />
+                        <View style={styles.bottomChildren}>{bottomChildren}</View>
+                    </View>
                 </View>
             </DropShadow>
         </DropShadow>

--- a/src/components/actionCard/ActionCard.tsx
+++ b/src/components/actionCard/ActionCard.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from 'react';
 import React from 'react';
-import { StyleSheet, View, ViewStyle } from 'react-native';
+import { Pressable, StyleSheet, View, ViewStyle } from 'react-native';
 import { useTheme } from '../../styles/themes';
-import { Button } from '../buttons/Button';
 import { Icon } from '../icons/Icon';
 import { Body } from '../typography/Body';
 import DropShadow from 'react-native-drop-shadow';
@@ -50,17 +49,17 @@ export const ActionCard = ({
         },
         title: {
             color: titleColor,
-            paddingTop: theme.sw.spacing.m,
+            paddingBottom: theme.sw.spacing.m,
             textAlign: 'center',
         },
         divider: {
             height: 1,
             width: '100%',
             backgroundColor: theme.sw.colors.neutral[200],
-            marginVertical: theme.sw.spacing.xl,
+            marginTop: theme.sw.spacing.m,
+            marginBottom: theme.sw.spacing.xs,
         },
         bottomChildren: {
-            paddingBottom: theme.sw.spacing.xl,
             alignItems: 'center',
         },
         bigShadow: {
@@ -87,15 +86,11 @@ export const ActionCard = ({
         <DropShadow style={styles.bigShadow}>
             <DropShadow style={styles.smallShadow}>
                 <View style={styles.container}>
-                    {onClose && (
-                        <Button style={styles.close} onClick={onClose} testID={buttonTestID}>
-                            <Icon name="close-fill" size={20} />
-                        </Button>
-                    )}
-                    <Body size="semi-bold" style={styles.title}>
-                        {title}
-                    </Body>
-                    <View style={{ padding: theme.sw.spacing.m }}>{children}</View>
+                    <Body style={styles.title}>{title}</Body>
+                    <Pressable style={styles.close} onPress={onClose} testID={buttonTestID}>
+                        <Icon name="close-fill" size={20} />
+                    </Pressable>
+                    <View>{children}</View>
                     {bottomChildren && (
                         <View style={{ width: '100%' }}>
                             <View style={styles.divider} />


### PR DESCRIPTION
Léger rework du composant action card (https://www.figma.com/file/MD0xdHA7E93GKAwkSRpduK/%F0%9F%93%B1-SW-Mobile---Design-Kit?type=design&node-id=1382-1630&t=i7KrmskjdGg0a8Yd-0) dont la maquette n'est a priori pas complètement validée.

Ce composant prend 2 enfants obligatoires : 1 au dessus et un en dessous du "divider".
Il a également un titre (dont on peut changer la couleur pour le statut "erreur")
Il a enfin un bouton "clear" qui peut être affiché ou non et qui prend un callback.

Les composants "quantités" (simple ou pour délotage) et "EAN" (pour scanner ou afficher un produit scanné) sont à gérer par l'appelant, de même que leurs états erreur / filled / readonly

La paramètre "disabled" sert à griser le fond mais étant donné qu'on ne gère pas les états des enfants, c'est encore un peu bancal et ça pourrait être revu.