### PR TITLE
SORD-145 :bug: accept comma as float separator

### DIFF
--- a/src/components/icons/IconProps.ts
+++ b/src/components/icons/IconProps.ts
@@ -111,3 +111,4 @@ export type IconName =
     | 'snow'
     | 'thunderstorms'
     | 'fail'
+;

--- a/src/components/numberSelector/NumberSelector.tsx
+++ b/src/components/numberSelector/NumberSelector.tsx
@@ -43,7 +43,7 @@ export const NumberSelector = ({
     const allowedMinus = (): boolean => {
         return minValue !== undefined && minValue < 0;
     };
-    const decimalRegex = allowedMinus() ? /^-?\d+[\.]?\d?$/ : /^\d+[\.]?\d?$/;
+    const decimalRegex = allowedMinus() ? /^-?\d+[\.,]?\d?$/ : /^\d+[\.,]?\d?$/;
     const integerRegex = allowedMinus() ? /^-?\d+$/ : /^\d+$/;
     const numberRegex = decimal ? decimalRegex : integerRegex;
     const onAdd = () => {


### PR DESCRIPTION
Quand l'emulateur est en anglais pas de soucis avec les points, quand il est en francais les points marchent plus.
J'ai reussi a reproduire la bug sur la smartapp mais pas sur storybook, donc je tente un fix un peu en blind. En meme temps pour la france ca parait pas deconnant d'accepter les virgules