### PR TITLE
🚨 fix tsc error on build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig",
-  "include": ["src"],
-  "exclude": ["src/**/*test.ts"]
+    "extends": "./tsconfig",
+    "include": ["src", "./modules.d.ts", "./jest.setup.ts"],
+    "exclude": ["src/**/*test.ts"]
 }


### PR DESCRIPTION
Les nouveaux types `jest-matcher` doivent être inclus dans le `tsconfig.build.json`, de la même manière que dans le `tsconfig.json`