### PR TITLE
🐛🔖 fix release output

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
     "extends": "./tsconfig",
-    "include": ["src", "./modules.d.ts", "./jest.setup.ts"],
-    "exclude": ["src/**/*test.ts"]
+    "include": ["src"],
+    "exclude": ["**/*.test.tsx", "**/*.test.ts"]
 }


### PR DESCRIPTION
Clean misconfigured tsconfing build file to fix the TS transpilation that make the 8.0.36 unusable.

it prevents tests file to be included in the final build as well.